### PR TITLE
switch up the hash algos used

### DIFF
--- a/Direct_Framework/Stored Procedures/omd.RegisterBatch.sql
+++ b/Direct_Framework/Stored Procedures/omd.RegisterBatch.sql
@@ -150,7 +150,7 @@ BEGIN TRY
     -- Evaluate the incoming values to see if the Batch should be updated.
     -- Note that the active indicator is excluded here, to allow it to be managed separately.
     DECLARE @NewChecksum BINARY(20) =
-    HASHBYTES('SHA1',
+    HASHBYTES('SHA2_512',
       @BatchType             + '!' +
       @BatchFrequency        + '!' +
       @BatchDescription
@@ -163,7 +163,7 @@ BEGIN TRY
     -- Evaluate the existing values to see if the Module requires to be updated.
     DECLARE @ExistingChecksum BINARY(20);
     SELECT @ExistingChecksum =
-    HASHBYTES('SHA1',
+    HASHBYTES('SHA2_512',
       COALESCE([BATCH_TYPE],        'N/A') + '!' +
       COALESCE([FREQUENCY_CODE],    'N/A') + '!' +
       COALESCE([BATCH_DESCRIPTION], 'N/A'))

--- a/Direct_Framework/Stored Procedures/omd.RegisterModule.sql
+++ b/Direct_Framework/Stored Procedures/omd.RegisterModule.sql
@@ -187,7 +187,7 @@ BEGIN TRY
     -- Note that the active indicator is excluded here,
     -- to allow it to be managed separately.
     DECLARE @NewChecksum BINARY(20) =
-    HASHBYTES('SHA1',
+    HASHBYTES('SHA2_512',
       @ModuleType             + '!' +
       @ModuleSourceDataObject + '!' +
       @ModuleTargetDataObject + '!' +
@@ -203,7 +203,7 @@ BEGIN TRY
     -- Evaluate the existing values to see if the Module requires to be updated.
     DECLARE @ExistingChecksum BINARY(20);
     SELECT @ExistingChecksum =
-    HASHBYTES('SHA1',
+    HASHBYTES('SHA2_512',
       COALESCE([MODULE_TYPE],         'N/A') + '!' +
       COALESCE([DATA_OBJECT_SOURCE],  'N/A') + '!' +
       COALESCE([DATA_OBJECT_TARGET],  'N/A') + '!' +

--- a/Direct_Framework/Stored Procedures/omd.TableCondensing.sql
+++ b/Direct_Framework/Stored Procedures/omd.TableCondensing.sql
@@ -216,7 +216,7 @@ BEGIN TRY
   SET @FinalQuery = 'WITH CondensingCTE AS' + CHAR(10);
   SET @FinalQuery = @FinalQuery + '(' + CHAR(10);
   SET @FinalQuery = @FinalQuery + 'SELECT' + CHAR(10);
-  SET @FinalQuery = @FinalQuery + '  HASHBYTES(''MD5'',' + CHAR(10);
+  SET @FinalQuery = @FinalQuery + '  HASHBYTES(''SHA2_512'',' + CHAR(10);
   SET @FinalQuery = @FinalQuery + @HashSnippet;
   SET @FinalQuery = @FinalQuery + '  ) AS FULL_ROW_CHECKSUM,' + CHAR(10);
   SET @FinalQuery = @FinalQuery + '  *' + CHAR(10);


### PR DESCRIPTION
fixes #38
mutes some security warnings, as md5 is deprecated and sha1 is considered less secure. this implementation uses them purely for change tracking, so no security concerns. updating the code should silence any warnings on this