### PR TITLE
45 v2 has typo in column name in post deploy script

### DIFF
--- a/Direct_Framework/DeploymentScripts/3-PostDeployment/omd_metadata.INTERNAL_PROCESSING_STATUS.sql
+++ b/Direct_Framework/DeploymentScripts/3-PostDeployment/omd_metadata.INTERNAL_PROCESSING_STATUS.sql
@@ -19,10 +19,10 @@ SET NOCOUNT ON;
 
 DECLARE @tblMerge TABLE(
   [INTERNAL_PROCESSING_STATUS_CODE]             NVARCHAR (100)  NOT NULL PRIMARY KEY CLUSTERED,
-  [INTERNAL_PROCESSING_STATUS_DESCRIPTION]      NVARCHAR (4000) NULL
+  [INTERNAL_PROCESSING_STATUS_CODE_DESCRIPTION]      NVARCHAR (4000) NULL
 );
 
-INSERT INTO @tblMerge([INTERNAL_PROCESSING_STATUS_CODE], [INTERNAL_PROCESSING_STATUS_DESCRIPTION])
+INSERT INTO @tblMerge([INTERNAL_PROCESSING_STATUS_CODE], [INTERNAL_PROCESSING_STATUS_CODE_DESCRIPTION])
 VALUES
   (N'Abort',     N'This exception case indicates that the instance in question was executed, but that another instance of the same Batch or Module is already running (see also the equivalent Execution Status Code for additional detail). This is one of the checks performed before the regular process (Module and/or Batch) can continue. If this situation occurs, all processing should stop; no data should be processed. The process will use the Internal Processing Status `Abort` to trigger the Module/Batch `Abort` event which sets the Execution Status Code to `Cancelled`, ending the process gracefully.'),
   (N'Cancel',    N'The instance evaluation has determined that it is not necessary to run this process (see also the equivalent Execution Status Code for additional detail). As with Abort, if the Internal Process Status code is `Cancel` then all further processing should stop after the Execution Status Code has also been updated to `Cancel`.'),
@@ -34,11 +34,11 @@ USING @tblMerge AS src
   ON  TARGET.[INTERNAL_PROCESSING_STATUS_CODE] = src.[INTERNAL_PROCESSING_STATUS_CODE]
 WHEN MATCHED THEN
   UPDATE
-  SET      [INTERNAL_PROCESSING_STATUS_DESCRIPTION] = src.[INTERNAL_PROCESSING_STATUS_DESCRIPTION]
+  SET      [INTERNAL_PROCESSING_STATUS_CODE_DESCRIPTION] = src.[INTERNAL_PROCESSING_STATUS_CODE_DESCRIPTION]
 WHEN NOT MATCHED THEN
   INSERT  ([INTERNAL_PROCESSING_STATUS_CODE]
-          ,[INTERNAL_PROCESSING_STATUS_DESCRIPTION])
+          ,[INTERNAL_PROCESSING_STATUS_CODE_DESCRIPTION])
   VALUES  ([INTERNAL_PROCESSING_STATUS_CODE]
-          ,[INTERNAL_PROCESSING_STATUS_DESCRIPTION]);
+          ,[INTERNAL_PROCESSING_STATUS_CODE_DESCRIPTION]);
 
 GO

--- a/Direct_Framework/DeploymentScripts/3-PostDeployment/omd_metadata.NEXT_RUN_STATUS.sql
+++ b/Direct_Framework/DeploymentScripts/3-PostDeployment/omd_metadata.NEXT_RUN_STATUS.sql
@@ -17,11 +17,11 @@
 SET NOCOUNT ON;
 
 DECLARE @tblMerge TABLE(
-  [NEXT_RUN_STATUS_CODE]             NVARCHAR (100)  NOT NULL PRIMARY KEY CLUSTERED,
-  [NEXT_RUN_STATUS_CODE_DESCRIPTION] NVARCHAR (4000) NULL
+  [NEXT_RUN_STATUS_CODE]  NVARCHAR (100)  NOT NULL PRIMARY KEY CLUSTERED,
+  [NEXT_RUN_DESCRIPTION]  NVARCHAR (4000) NULL
 );
 
-INSERT INTO @tblMerge([NEXT_RUN_STATUS_CODE], [NEXT_RUN_STATUS_CODE_DESCRIPTION])
+INSERT INTO @tblMerge([NEXT_RUN_STATUS_CODE], [NEXT_RUN_DESCRIPTION])
 VALUES
   (N'Cancel',    N'Administrators can manually set this code to for the Next Run Status (i.e. this will not be automatically set by the DIRECT controls) to force a one-off skip of the instance.'),
   (N'Proceed',   N'The `Proceed` code will direct the next run of the Batch/Module to continue processing. This is the default value. Each process step will evaluate the Internal Process Status Code and continue only if it was set to `Proceed`. After the rollback has been completed the `Proceed` value is the code that is required to initiate the main process.'),
@@ -32,11 +32,11 @@ USING @tblMerge AS src
   ON  TARGET.[NEXT_RUN_STATUS_CODE] = src.[NEXT_RUN_STATUS_CODE]
 WHEN MATCHED THEN
   UPDATE
-  SET      [NEXT_RUN_STATUS_CODE_DESCRIPTION] = src.[NEXT_RUN_STATUS_CODE_DESCRIPTION]
+  SET      [NEXT_RUN_DESCRIPTION] = src.[NEXT_RUN_DESCRIPTION]
 WHEN NOT MATCHED THEN
   INSERT  ([NEXT_RUN_STATUS_CODE]
-          ,[NEXT_RUN_STATUS_CODE_DESCRIPTION])
+          ,[NEXT_RUN_DESCRIPTION])
   VALUES  ([NEXT_RUN_STATUS_CODE]
-          ,[NEXT_RUN_STATUS_CODE_DESCRIPTION]);
+          ,[NEXT_RUN_DESCRIPTION]);
 
 GO


### PR DESCRIPTION
addresses typos in post-deploys in v2

closes #45 